### PR TITLE
辞書の単語を文字列長の長い順に取得

### DIFF
--- a/src/main/java/dev/cosgy/textToSpeak/audio/Dictionary.kt
+++ b/src/main/java/dev/cosgy/textToSpeak/audio/Dictionary.kt
@@ -106,7 +106,7 @@ class Dictionary private constructor(bot: Bot) {
     }
 
     private fun getWordsFromDatabase(guildId: Long): Optional<HashMap<String?, String?>> {
-        val sql = "SELECT * FROM Dictionary WHERE guild_id = ?"
+        val sql = "SELECT * FROM Dictionary WHERE guild_id = ? ORDER BY LENGTH(word) DESC"
         try {
             connection.prepareStatement(sql).use { ps ->
                 ps.setLong(1, guildId)


### PR DESCRIPTION
### このプルリクエストは...

- [ ] バグを修正
- [ ] 新機能を追加
- [x] 既存の機能を改善
- [ ] コードの品質やパフォーマンスの向上

### 説明

辞書に登録されている単語の置換を、文字列の長い単語から試みます。
例えば「bot: ボット」「robot: ロボット」という単語が辞書に登録されている場合、文章中の「bot」が先に置換されると
「a robot.」 → 「a roボット.」
となってしまうのでこれをなるべく防ぎます。

### 目的

### 関連する問題
