### PR TITLE
fix: JLReadCmdが引数付きで呼ばれた場合にsettings.setReadNameを書き換えている問題の修正

### DIFF
--- a/src/main/java/dev/cosgy/textToSpeak/commands/admin/JLReadCmd.kt
+++ b/src/main/java/dev/cosgy/textToSpeak/commands/admin/JLReadCmd.kt
@@ -46,7 +46,7 @@ class JLReadCmd(private val bot: Bot) : AdminCommand() {
             event.reply("ボイスチャンネルにユーザーが参加、退出した際の読み上げを${if (settings.isJoinAndLeaveRead()) "有効" else "無効"}にしました。").queue()
         } else {
             val args = event.getOption("value")!!.asBoolean
-            settings.setReadName(args)
+            settings.setJoinAndLeaveRead(args)
             event.reply("ボイスチャンネルにユーザーが参加、退出した際の読み上げを${if (args) "有効" else "無効"}にしました。").queue()
         }
     }


### PR DESCRIPTION
### このプルリクエストは...

- [x] バグを修正
- [ ] 新機能を追加
- [ ] 既存の機能を改善
- [ ] コードの品質やパフォーマンスの向上

### 説明

- JLReadCmdが引数付きで呼ばれた場合にsettings.setReadNameを書き換えている問題の修正


### 目的

- JLReadCmdを意図した動作に修正

### 関連する問題
