### PR TITLE
Regex.escape()を行うことで辞書機能が動作しなくなっていた問題を修正

### DIFF
--- a/src/main/java/dev/cosgy/textToSpeak/audio/VoiceCreation.kt
+++ b/src/main/java/dev/cosgy/textToSpeak/audio/VoiceCreation.kt
@@ -53,7 +53,7 @@ class VoiceCreation( // 各種設定の値を保持するためのフィール�
         val words = bot.dictionary?.getWords(guild.idLong)
         var dicMsg = sanitizeMessage(message)
         for ((key, value) in words!!) {
-            dicMsg = dicMsg.replace(Regex.escape(key!!), value!!)
+            dicMsg = dicMsg.replace(key!!, value!!)
         }
 
         toKatakanaIfEnglishExists(dicMsg)


### PR DESCRIPTION
いつも、すばらしいbotを作成メンテナンスいただき、ありがとうございます。

### このプルリクエストは...

- [x] バグを修正
- [ ] 新機能を追加
- [ ] 既存の機能を改善
- [ ] コードの品質やパフォーマンスの向上

### 説明

version: `0.4.1` にて行われた辞書の文字列のreplace処理において、文字列のマッチングが行われなくなり、結果として辞書機能が動作しておりませんでした。

https://github.com/Cosgy-Dev/TextToSpeakBot/commit/f786b2d9d9ae13a35d42b0c754f5526430b54952

例えば、`bootjp` という文字列を `ブート` で辞書登録されていた場合、`Regex.escape(key!!)` を使った場合は `\Qbootjp\E` となり正規表現に一致しないため、辞書の読み仮名が利用されません。

```
Regex.escape(key!!): \Qbootjp\E
key!!.toRegex(): bootjp
```

そこで、このpull requestではシンプルな文字列によるリプレース処理に変更し、この問題を修正します。

https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/replace.html

（辞書に正規表現を含む単語が登録されていないことを前提としています）

### 目的

辞書機能における不具合の修正

### 関連する問題

ここには関連する問題を#[issuesの番目] で表示して下さい。


