### PR TITLE
Sticker(スタンプ)名を読み上げ文に追加

### DIFF
--- a/src/main/java/dev/cosgy/textToSpeak/listeners/MessageListener.kt
+++ b/src/main/java/dev/cosgy/textToSpeak/listeners/MessageListener.kt
@@ -63,6 +63,7 @@ class MessageListener(private val bot: Bot) : ListenerAdapter() {
 
             // URLを置き換え
             msg = msg.replace("(http://|https://)[\\w.\\-/:#?=&;%~+]+".toRegex(), "ゆーあーるえる")
+            message.getStickers().forEach { sticker -> msg += " " + sticker.getName() }
             if (textChannel === settingText) {
                 val settings = bot.settingsManager.getSettings(guild)
                 if (settings.isReadName()) {


### PR DESCRIPTION
スタンプを読み上げるようにします。

### このプルリクエストは...

- [ ] バグを修正
- [ ] 新機能を追加
- [x] 既存の機能を改善
- [ ] コードの品質やパフォーマンスの向上

### 説明

Sticker(スタンプ)が投稿された場合にスタンプに設定されている「スタンプの名前」を読み上げるようにします。

### 目的

### 関連する問題

